### PR TITLE
Changes to Parser unit tests

### DIFF
--- a/src/api/parser/jest.config.js
+++ b/src/api/parser/jest.config.js
@@ -3,7 +3,7 @@ const baseConfig = require('../../../jest.config.base');
 module.exports = {
   ...baseConfig,
   rootDir: '../../..',
-  setupFiles: ['<rootDir>/src/api/parser/jest.setup.js', '<rootDir>/test/jest.setup.js'],
+  setupFiles: ['<rootDir>/src/api/parser/jest.setup.js'],
   testMatch: ['<rootDir>/src/api/parser/test/*.test.js'],
   collectCoverageFrom: ['<rootDir>/src/api/parser/src/**/*.js'],
 };

--- a/src/api/parser/jest.setup.js
+++ b/src/api/parser/jest.setup.js
@@ -1,1 +1,13 @@
-process.env = { ...process.env, MOCK_REDIS: '1', MOCK_ELASTIC: '1', LOG_LEVEL: 'silent' };
+const fetch = require('jest-fetch-mock');
+
+// Mock fetch for the Parser tests
+jest.setMock('node-fetch', fetch);
+
+process.env = {
+  ...process.env,
+  MOCK_REDIS: '1',
+  MOCK_ELASTIC: '1',
+  LOG_LEVEL: 'silent',
+  NODE_ENV: 'test',
+  FEED_URL_INTERVAL_MS: '200',
+};

--- a/src/api/parser/test/url-parser.test.js
+++ b/src/api/parser/test/url-parser.test.js
@@ -20,43 +20,4 @@ describe('url-parser tests', () => {
   `('$name', ({ url, port, expected }) => {
     expect(urlParser(url, port)).toBe(expected);
   });
-
-  // test('urlParser with double ports', () => {
-  //   const result = urlParser(testUrlWithPort, testport);
-  //   expect(result).toBe(expectedReturn1);
-  // });
-
-  // test('urlParser with 1 string port', () => {
-  //   const result = urlParser(testUrlWithoutPort, testport);
-  //   expect(result).toBe(expectedReturn1);
-  // });
-
-  // test('urlParser with invalid url', () => {
-  //   const result = urlParser('', testport);
-  //   expect(result).toBe(null);
-  // });
-
-  // test('urlParser with url with no port and no port', () => {
-  //   const result = urlParser(testUrlWithoutPort);
-  //   expect(result).toBe(expectedReturn2);
-  // });
-
-  // test('urlPaser with port being a null value', () => {
-  //   const result = urlParser(testUrlWithoutPort, null);
-  //   expect(result).toBe(expectedReturn2);
-  // });
-
-  // test('urlPaser with port being an integer', () => {
-  //   const result = urlParser(testUrlWithoutPort, Number(testport));
-  //   expect(result).toBe(expectedReturn1);
-  // });
-
-  // test('urlPaser with port being an invalid string', () => {
-  //   const result = urlParser(testUrlWithoutPort, 'invalid');
-  //   expect(result).toBe(expectedReturn2);
-  // });
-  // test('urlPaser with an out of range port', () => {
-  //   const result = urlParser(testUrlWithoutPort, 999999);
-  //   expect(result).toBe(expectedReturn2);
-  // });
 });

--- a/src/api/parser/test/wiki-feed-parser.test.js
+++ b/src/api/parser/test/wiki-feed-parser.test.js
@@ -1,5 +1,4 @@
-/* global fetch */
-global.fetch = require('node-fetch');
+const { fetch } = require('@senecacdot/satellite');
 
 const getWikiFeeds = require('../src/utils/wiki-feed-parser');
 


### PR DESCRIPTION
- Moved old backend test setup to Parser
- Uncommented url-parser unit tests
- Modified wiki-feed-test fetch to use mocked Satellite fetch

## Issue This PR Addresses
- `pnpm test src/api/parser` passes all unit tests
- I've uncommented out the code in `url-parser.test` they pass fine, so maybe we could keep them?
- updated the test setup to include the old backend setup so we can update the Parser test configs
- I've changed the `fetch` in `wiki-feed-parser.test` to use the `{ fetch }` from Satellite (which is mocked from the test setup). I figured this seemed more appropriate since we're using the `fetch` from Satellite in the actual file now

